### PR TITLE
update pkg name from "mathalfa" to "mathalpha"

### DIFF
--- a/Style/artratex.sty
+++ b/Style/artratex.sty
@@ -284,7 +284,7 @@
     %- Math font: <default: computer modern|others: font packages>
     \RequirePackage[cmintegrals]{newtxmath}% times font, load after amsmath and newtxtext packages
     \RequirePackage{mathrsfs}% enable \mathscr for script alphabet
-    \RequirePackage[cal=cm]{mathalfa}% map styles for calligraphic \mathcal and script \mathscr alphabet
+    \RequirePackage[cal=cm]{mathalpha}% map styles for calligraphic \mathcal and script \mathscr alphabet
 \else% <xelatex> or <lualatex> call system fonts
     \RequirePackage{fontspec}% support calling system fonts
     %- Font properties: <family> + <weight> + <shape> + <size>
@@ -313,7 +313,6 @@
     %- Math font: <default: computer modern|others: font packages <newtxmath|unicode-math>>
     %\RequirePackage[cmintegrals]{newtxmath}% times font, load after amsmath and newtxtext packages
     %\RequirePackage{mathrsfs}% enable \mathscr for script alphabet
-    %\RequirePackage[cal=cm]{mathalfa}% map styles for calligraphic \mathcal and script \mathscr alphabet
     \IfFontExistsTF{XITS-Regular.otf}{%
     \RequirePackage{unicode-math}% unicode font configuration <XITS|STIX2>
     \def\boldsymbol#1{\symbf{#1}}% treat obsoleteness
@@ -381,7 +380,7 @@
     \RequirePackage{newtxtext}% main font
     \RequirePackage[cmintegrals]{newtxmath}% times font, load after amsmath and newtxtext packages
     \RequirePackage{mathrsfs}% enable \mathscr for script alphabet
-    \RequirePackage[cal=cm]{mathalfa}% map styles for calligraphic \mathcal and script \mathscr alphabet
+    \RequirePackage[cal=cm]{mathalpha}% map styles for calligraphic \mathcal and script \mathscr alphabet
     }
     %- Text font: Chinese
     \ifartx@windows%


### PR DESCRIPTION
根据 README 信息 ([link](https://www.ctan.org/pkg/mathalpha))，

> Pack­age math­alfa was re­named to math­al­pha.

将模板中使用的 `mathalfa` 包，更名为 `mathalpha`。

