### PR TITLE
Update Backmatter.tex

### DIFF
--- a/Tex/Backmatter.tex
+++ b/Tex/Backmatter.tex
@@ -1,11 +1,20 @@
 %---------------------------------------------------------------------------%
 %->> Backmatter
 %---------------------------------------------------------------------------%
+\chapter[致谢]{致\quad 谢}\chaptermark{致\quad 谢}% syntax: \chapter[目录]{标题}\chaptermark{页眉}
+%\thispagestyle{noheaderstyle}% 如果需要移除当前页的页眉
+%\pagestyle{noheaderstyle}% 如果需要移除整章的页眉
+
+感激casthesis作者吴凌云学长，gbt7714-bibtex-style
+开发者zepinglee，和ctex众多开发者们。若没有他们的辛勤付出和非凡工作，\LaTeX{}菜鸟的我是无法完成此国科大学位论文\LaTeX{}模板ucasthesis的。在\LaTeX{}中的一点一滴的成长源于开源社区的众多优秀资料和教程，在此对所有\LaTeX{}社区的贡献者表示感谢！
+
+ucasthesis国科大学位论文\LaTeX{}模板的最终成型离不开以霍明虹老师和丁云云老师为代表的国科大学位办公室老师们制定的官方指导文件和众多ucasthesis用户的热心测试和耐心反馈，在此对他们的认真付出表示感谢。特别对国科大的赵永明同学的众多有效反馈意见和建议表示感谢，对国科大本科部的陆晴老师和本科部学位办的丁云云老师的细致审核和建议表示感谢。谢谢大家的共同努力和支持，让ucasthesis为国科大学子使用\LaTeX{}撰写学位论文提供便利和高效这一目标成为可能。
+
 \chapter{作者简历及攻读学位期间发表的学术论文与研究成果}
 
 \textbf{本科生无需此部分}。
 
-\section*{作者简历}
+\section*{作者简历：}
 
 \subsection*{casthesis作者}
 
@@ -15,7 +24,7 @@
 
 莫晃锐，湖南省湘潭县人，中国科学院力学研究所硕士研究生。
 
-\section*{已发表(或正式接受)的学术论文:}
+\section*{已发表（或正式接受）的学术论文：}
 
 {
 \setlist[enumerate]{}% restore default behavior
@@ -24,22 +33,13 @@
 \end{enumerate}
 }
 
-\section*{申请或已获得的专利:}
+\section*{申请或已获得的专利：}
 
-(无专利时此项不必列出)
+（无专利时此项不必列出）
 
-\section*{参加的研究项目及获奖情况:}
+\section*{参加的研究项目及获奖情况：}
 
 可以随意添加新的条目或是结构。
-
-\chapter[致谢]{致\quad 谢}\chaptermark{致\quad 谢}% syntax: \chapter[目录]{标题}\chaptermark{页眉}
-\thispagestyle{noheaderstyle}% 如果需要移除当前页的页眉
-%\pagestyle{noheaderstyle}% 如果需要移除整章的页眉
-
-感激casthesis作者吴凌云学长，gbt7714-bibtex-style
-开发者zepinglee，和ctex众多开发者们。若没有他们的辛勤付出和非凡工作，\LaTeX{}菜鸟的我是无法完成此国科大学位论文\LaTeX{}模板ucasthesis的。在\LaTeX{}中的一点一滴的成长源于开源社区的众多优秀资料和教程，在此对所有\LaTeX{}社区的贡献者表示感谢！
-
-ucasthesis国科大学位论文\LaTeX{}模板的最终成型离不开以霍明虹老师和丁云云老师为代表的国科大学位办公室老师们制定的官方指导文件和众多ucasthesis用户的热心测试和耐心反馈，在此对他们的认真付出表示感谢。特别对国科大的赵永明同学的众多有效反馈意见和建议表示感谢，对国科大本科部的陆晴老师和本科部学位办的丁云云老师的细致审核和建议表示感谢。谢谢大家的共同努力和支持，让ucasthesis为国科大学子使用\LaTeX{}撰写学位论文提供便利和高效这一目标成为可能。
 
 \cleardoublepage[plain]% 让文档总是结束于偶数页，可根据需要设定页眉页脚样式，如 [noheaderstyle]
 %---------------------------------------------------------------------------%


### PR DESCRIPTION
根据[学位论文撰写规范](https://onestop.ucas.edu.cn/home/info/5d00dded-e51e-4cde-b511-75c195f49589/2)更新了 Backmatter.tex 中的部分样式与内容：

1. 根据《中国科学院大学研究生学位论文撰写规范指导意见》第一条，`学位论文一般由以下几个部分组成：封面、原创性声明及授权使用声明、摘要、目录、正文、参考文献、附录、致谢、作者简历及攻读学位期间发表的学术论文与研究成果等。`，目前致谢是放在简历前的，因此此 PR 修改了顺序；
2. 根据上述文档第二条第三项《页眉》，`参考文献、附录、致谢等的页眉，奇数标明“参考文献”、“附录”、“致谢”等，偶数页上标明论文题目。页眉居中设置。`，因此注释掉了 `noheaderstyle`；
3. 根据上述文档附件一 - 样章（以及老师要求），简历里的冒号和括号要用中文全角符号。

