### PR TITLE
补充了本科生版本的原创性声明

### DIFF
--- a/Style/ucasthesis.cfg
+++ b/Style/ucasthesis.cfg
@@ -115,6 +115,12 @@
     或撰写过的研究成果。对论文所涉及的研究工作做出贡献的其他个人和集体，均已在文中
     以明确方式标明或致谢。
 }
+\def\ucas@value@ch@declare@creativity@bac{%
+    本人郑重声明：所呈交的学位论文是本人在导师的指导下独立进行研究工作所取得的成果。
+    尽我所知，除文中已经注明引用的内容外，本论文不包含任何其他个人或集体已经发表
+    或撰写过的研究成果。对论文所涉及的研究工作做出贡献的其他个人和集体，均已在文中
+    以明确方式标明或致谢。本人完全意识到本声明法律结果由本人承担。
+}
 \def\ucas@label@ch@declare@author{作者签名：}
 \def\ucas@label@ch@declare@advisor{导师签名：}
 \def\ucas@label@ch@declare@date{日\quad\quad 期：}

--- a/Style/ucasthesis.cls
+++ b/Style/ucasthesis.cls
@@ -249,6 +249,7 @@
         \def\ucas@value@en@thesistype{\ucas@value@en@thesistype@bac}%
         \def\maketitle{\maketitle@xpdc}
         \def\MAKETITLE{\MAKETITLE@xpdc}
+        \def\ucas@value@ch@declare@creativity{\ucas@value@ch@declare@creativity@bac}
     }{%
     \ucasifstreq{\ucas@value@en@degree}{Master}{%
         \def\ucas@label@ch@thesis{\ucas@label@ch@thesis@mas}%


### PR DESCRIPTION
本科生版本的原创性声明较之研究生版本多了一句话，故修改 `.cfg` 和 `.cls` 文件。

依据：
![image](https://user-images.githubusercontent.com/42308170/162887025-c2d35a72-9c39-446b-97f0-fde81d9cbaf4.png)
来源：[中国科学院大学本科生毕业论文撰写规范指导意见（2016）](https://github.com/mohuangrui/ucasthesis/files/8469818/default.pdf)

