### PR TITLE
英文标题页中，作者名前的“By”需要改为“by”

### DIFF
--- a/Style/ucasthesis.cls
+++ b/Style/ucasthesis.cls
@@ -426,7 +426,7 @@
 
         {\ucas@label@en@statement}
 
-        {By}
+        {by}
 
         {\ucas@value@en@author}
 


### PR DESCRIPTION
根据计算所新发要求（即 2023-06-04下发的《例说学位论文检查V0.2》Page4），
论文的英文标题页中，作者名前不应为“By”，需要改为“by”。

[例说学位论文检查-卜东波-Version0.2.pdf](https://github.com/mohuangrui/ucasthesis/files/11645467/-.-Version0.2.pdf)
